### PR TITLE
Compile fails without sys/types.h

### DIFF
--- a/examples/conf_example.c
+++ b/examples/conf_example.c
@@ -23,8 +23,8 @@ int main(int argc, char **argv) {
 	cfuconf_t *conf = NULL;
 	char *error = NULL;
 
-	argc = argc;
-	argv = argv;
+	(void)argc;
+	(void)argv;
 
 	if (cfuconf_parse_file(file_path, &conf, &error) < 0) {
 		fprintf(stderr, "Error loading conf file: %s\n", error);

--- a/examples/conf_example2.c
+++ b/examples/conf_example2.c
@@ -29,8 +29,8 @@ int main(int argc, char **argv) {
 		"    SetVar Test4 Val4\n"
 		"</test_container>\n";
 
-	argc = argc;
-	argv = argv;
+	(void)argc;
+	(void)argv;
 
 	if (cfuconf_parse_buffer(buffer, &conf, &error) < 0) {
 		fprintf(stderr, "Error loading conf buffer: %s\n", error);

--- a/examples/hash_usage.c
+++ b/examples/hash_usage.c
@@ -36,9 +36,9 @@ strncasecmp(const char *s1, const char *s2, size_t n)
 
 static int
 remove_func(void *key, size_t key_size, void *data, size_t data_size, void *arg) {
-	data_size = data_size;
-	data = data;
-	arg = arg;
+	(void)data_size;
+	(void)data;
+	(void)arg;
 
 	if (key_size > 7) {
 		if (!strncasecmp(key, "content", 7)) {
@@ -55,8 +55,8 @@ int main(int argc, char **argv) {
 	char list[32][2][32];
 	size_t i;
 
-	argc = argc;
-	argv = argv;
+	(void)argc;
+	(void)argv;
 
 	cfuhash_set_flag(hash, CFUHASH_FROZEN_UNTIL_GROWS);
 

--- a/examples/large_hash.c
+++ b/examples/large_hash.c
@@ -26,7 +26,7 @@ dup_str(const char *str) {
 	return ns;
 }
 
-static u_int32_t
+static uint32_t
 hash_func1(const void *key, size_t length) {
 	size_t i = length;
 	unsigned int hash = 0;
@@ -50,7 +50,7 @@ hash_func1(const void *key, size_t length) {
   c -= a; c -= b; c ^= (b>>15);			\
 }
 
-typedef u_int32_t ub4;
+typedef uint32_t ub4;
 
 static unsigned int
 hash_func_tc(const void *key, size_t length)
@@ -98,7 +98,7 @@ hash_func_tc(const void *key, size_t length)
 
 
 static int
-time_it(cfuhash_function_t hf, double *elapsed_time, u_int32_t num_tests) {
+time_it(cfuhash_function_t hf, double *elapsed_time, uint32_t num_tests) {
 	cfuhash_table_t *hash = cfuhash_new_with_initial_size(30);
 	char key[32];
 	char value[32];
@@ -135,7 +135,7 @@ time_it(cfuhash_function_t hf, double *elapsed_time, u_int32_t num_tests) {
 
 int main(int argc, char **argv) {
 	double elapsed_time = 0;
-	u_int32_t num_tests = 3000000;
+	uint32_t num_tests = 3000000;
 
 	(void)argc;
 	(void)argv;

--- a/examples/large_hash.c
+++ b/examples/large_hash.c
@@ -137,8 +137,8 @@ int main(int argc, char **argv) {
 	double elapsed_time = 0;
 	u_int32_t num_tests = 3000000;
 
-	argc = argc;
-	argv = argv;
+	(void)argc;
+	(void)argv;
 
 	printf("mutex is %lu bytes\n", sizeof(pthread_mutex_t));
 

--- a/examples/large_hash.c
+++ b/examples/large_hash.c
@@ -3,13 +3,15 @@
  * Change log:
  */
 
-#include "cfuhash.h"
-#include "cfutimer.h"
+#include <sys/types.h>
 
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
 #include <pthread.h>
+
+#include "cfuhash.h"
+#include "cfutimer.h"
 
 static
 void free_data(void *data) {

--- a/examples/opt_example.c
+++ b/examples/opt_example.c
@@ -17,8 +17,8 @@ int main(int argc, char **argv) {
 	char *help = NULL;
 	int i = 0;
 
-	argc = argc;
-	argv = argv;
+	(void)argc;
+	(void)argv;
 
 	cfuopt_add_entry(opt, "verbose|v!", &verbose, "Verbosity", "");
 	cfuopt_add_entry(opt, "file|f:s", &file, "File to load", "FILE");

--- a/examples/strings.c
+++ b/examples/strings.c
@@ -34,7 +34,7 @@ int main(int argc, char **argv) {
 		"Accept: image/gif, image/x-xbitmap, image/jpeg, image/pjpeg, */*\r\n");
 	cfustring_t **header_lines = NULL;
 
-	argc = argc; argv = argv; /* avoid compiler warnings */
+	(void)argc; (void)argv; /* avoid compiler warnings */
 
 	cfustring_append(buf, "test^*string%2^*3");
 	strings = cfustring_split_to_c_str(buf, &num_strings, 0, "%", "^*", NULL);

--- a/src/cfuconf.c
+++ b/src/cfuconf.c
@@ -736,9 +736,9 @@ print_sub_container_foreach_fn(void *name, size_t key_size, void *data, size_t d
 	void *arg) {
 	directive_foreach_ds *ds = (directive_foreach_ds *)arg;
 
-	name = name;
-	key_size = key_size;
-	data_size = data_size;
+	(void)name;
+	(void)key_size;
+	(void)data_size;
 
 	print_indent(ds->depth, ds->fp);
 	fprintf(ds->fp, "container %s '%s'\n", ds->name, (char *)name);
@@ -754,8 +754,8 @@ print_container_foreach_fn(void *name, size_t key_size, void *data, size_t data_
 	memcpy(new_ds, ds, sizeof(directive_foreach_ds));
 	new_ds->name = name;
 
-	key_size = key_size;
-	data_size = data_size;
+	(void)key_size;
+	(void)data_size;
 
 	cfuhash_foreach((cfuhash_table_t *)data, print_sub_container_foreach_fn, new_ds);
 	free(new_ds);
@@ -769,7 +769,7 @@ print_directive_list_foreach_fn(void *data, size_t data_size, void *arg) {
 	directive_foreach_ds *ds = (directive_foreach_ds *)arg;
 	char *str = NULL;
 
-	data_size = data_size;
+	(void)data_size;
 	if (!val_list) return 0;
 	assert(cfu_is_list(val_list));
 	str = cfulist_join(val_list, ", ");
@@ -785,8 +785,8 @@ print_conf_foreach_directive(void *name, size_t key_size, void *data, size_t dat
 	cfulist_t *this_directive_list = data;
 	directive_foreach_ds *new_ds = calloc(1, sizeof(directive_foreach_ds));
 
-	key_size = key_size;
-	data_size = data_size;
+	(void)key_size;
+	(void)data_size;
 
 	new_ds->fp = ds->fp;
 	new_ds->depth = ds->depth;

--- a/src/cfuhash.c
+++ b/src/cfuhash.c
@@ -812,8 +812,8 @@ typedef struct _pretty_print_arg {
 static int
 _pretty_print_foreach(void *key, size_t key_size, void *data, size_t data_size, void *arg) {
 	_pretty_print_arg *parg = (_pretty_print_arg *)arg;
-	key_size = key_size;
-	data_size = data_size;
+	(void)key_size;
+	(void)data_size;
 	parg->count += fprintf(parg->fp, "\t\"%s\" => \"%s\",\n", (char *)key, (char *)data);
 	return 0;
 }

--- a/src/cfulist.c
+++ b/src/cfulist.c
@@ -486,7 +486,7 @@ static int
 _join_foreach_fn(void *data, size_t data_size, void *arg) {
 	_join_foreach_struct *stuff = (_join_foreach_struct *)arg;
 
-	data_size = data_size;
+	(void)data_size;
 	if (stuff->count) cfustring_append(stuff->string, stuff->delimiter);
 	stuff->count++;
 	cfustring_append(stuff->string, (char *)data);

--- a/src/cfuopt.c
+++ b/src/cfuopt.c
@@ -187,7 +187,7 @@ struct _add_entry_struct {
 static int
 _add_to_option_map(void *data, size_t data_size, void *arg) {
 	struct _add_entry_struct *es = (struct _add_entry_struct *)arg;
-	data_size = data_size;
+	(void)data_size;
 
 	cfuhash_put(es->context->option_map, (char *)data, (void *)es->entry);
 
@@ -300,7 +300,7 @@ typedef struct {
 static int
 _update_extra(void *data, size_t data_size, void *arg) {
 	_update_extra_ds *ds = (_update_extra_ds *)arg;
-	data_size = data_size;
+	(void)data_size;
 	ds->argv[ds->count] = (char *)data;
 	ds->count++;
 
@@ -320,7 +320,7 @@ cfuopt_parse(cfuopt_t *context, int *argc, char ***argv, char **error) {
 	cfuopt_list_entry_t *entry = NULL;
 	size_t extra_count = 0;
 
-	error = error;
+	(void)error;
 
 	if (!context) return;
 	if (*argc < 1) return;
@@ -461,9 +461,9 @@ _cfuopt_pretty_print_foreach(void *key, size_t key_size, void *data, size_t data
 	cfuopt_list_entry_t *list_entry = data;
 	char *str = NULL;
 
-	key_size = key_size;
-	data_size = data_size;
-	arg = arg;
+	(void)key_size;
+	(void)data_size;
+	(void)arg;
 	ARG_TYPE_TO_STR(list_entry->arg_type, str);
 	printf("%s=%p (%s - %s) => %s, \"%s\"\n", name, (void *)list_entry, (list_entry->required ? "required" : "optional"), str, list_entry->description, list_entry->arg_description);
 
@@ -486,7 +486,7 @@ _param_map_fn(void *data, size_t data_size, void *arg, size_t *new_data_size) {
 	size_t len = 0;
 	cfuopt_list_entry_t *opt = (cfuopt_list_entry_t *)arg;
 
-	data_size = data_size;
+	(void)data_size;
 	if (!name) return NULL;
 	len = strlen(name);
 	*new_data_size = -1;
@@ -536,7 +536,7 @@ _find_foreach_fn(void *data, size_t data_size, void *arg) {
 	param_full_list = cfulist_map(opt->param_names, _param_map_fn, opt);
 	desc = cfulist_join(param_full_list, ", ");
 
-	data_size = data_size;
+	(void)data_size;
 
 	cfulist_destroy_with_free_fn(param_full_list, _simple_list_free_fn);
 
@@ -576,7 +576,7 @@ _get_help_lines(void *data, size_t data_size, void *arg) {
 	const char *desc = NULL;
 	char *line = NULL;
 
-	data_size = data_size;
+	(void)data_size;
 
 	left_col = desc_ds->desc;
 


### PR DESCRIPTION
uint32_t (and u_int32_t) is in types.h.

Also, new clangs complain about self assignment; proper way to show unused variables is (void)variable;

Chris
