### PR TITLE
Add cfulist_delete_data [too messy]

### DIFF
--- a/doc/libcfu.texi
+++ b/doc/libcfu.texi
@@ -509,6 +509,11 @@ cfulist_map().  The return value is used to build a new list.
  Pop a value from the end of the list (removing it from the list).
 @end deftypefun
 
+@deftypefun void cfulist_delete_data (cfulist_t * @var{list}, void * @var{data})
+
+ Deletes the entry in the list associated with value.
+@end deftypefun
+
 @deftypefun {int} cfulist_unshift_data (cfulist_t * @var{list}, void * @var{data}, size_t @var{data_size})
 
  Add a value at the beginning of the list. 

--- a/src/cfulist.c
+++ b/src/cfulist.c
@@ -412,6 +412,27 @@ cfulist_pop(cfulist_t *list) {
 	return NULL;
 }
 
+void
+cfulist_delete_data(cfulist_t *list, void *data) {
+	size_t i = 0;
+	cfulist_entry *ptr = NULL;
+
+	if (!list) {
+		return;
+	}
+
+	lock_list(list);
+	
+	if (list->entries) {
+		for (i = 0, ptr = list->entries; ptr && ptr->data != data; i++, ptr = ptr->next);
+		if (ptr && ptr->data == data) {
+			(ptr->prev)->next = ptr->next;
+		}
+	}
+
+	unlock_list(list);
+}
+
 int
 cfulist_unshift(cfulist_t *list, void *data) {
 	return cfulist_unshift_data(list, data, 0);

--- a/src/cfulist.c
+++ b/src/cfulist.c
@@ -414,7 +414,6 @@ cfulist_pop(cfulist_t *list) {
 
 void
 cfulist_delete_data(cfulist_t *list, void *data) {
-	size_t i = 0;
 	cfulist_entry *ptr = NULL;
 
 	if (!list) {
@@ -424,9 +423,11 @@ cfulist_delete_data(cfulist_t *list, void *data) {
 	lock_list(list);
 	
 	if (list->entries) {
-		for (i = 0, ptr = list->entries; ptr && ptr->data != data; i++, ptr = ptr->next);
+		for (ptr = list->entries; ptr && ptr->data != data; ptr = ptr->next)
+		;
 		if (ptr && ptr->data == data) {
 			(ptr->prev)->next = ptr->next;
+			free (ptr);
 		}
 	}
 

--- a/src/cfulist.h
+++ b/src/cfulist.h
@@ -81,6 +81,9 @@ int cfulist_push_data(cfulist_t *list, void *data, size_t data_size);
 /* Pop a value from the end of the list. */
 int cfulist_pop_data(cfulist_t *list, void **data, size_t *data_size);
 
+/* Deletes the entry in the list associated with value. */
+void cfulist_delete_data(cfulist_t *list, void *data);
+
 /* Add a value at the beginning of the list. */
 int cfulist_unshift_data(cfulist_t *list, void *data, size_t data_size);
 


### PR DESCRIPTION
It is important to let the programmer remove a node from the linked list, which is a very common operation.